### PR TITLE
Fix scriptanalyzer settings and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- New private function Format-IPAddressGroup created to centralize logic for formatting IP addresses for API calls.
+
 ### Changed
-- Added scriptanalyzer exceptions for "PSUseSingularNouns" per [issue #40](https://github.com/techservicesillinois/SecOps-Powershell-Qualys/issues/40)
+
 ### Removed
+
+## [1.4.0] - 2021-10-05
+
+### Added
+
+- New function Stop-QualysScan
+
+### Changed
+
+- Added blank scriptanalyzer param for 'CheckID' on all scripts using the 'PSUseSingularNouns' attribute as this was causing errors
+- Update all Markdown Help
+
+## [1.3.3] - 2021-08-26
+
+### Added
+
+- New private function Format-IPAddressGroup created to centralize logic for formatting IP addresses for API calls.
+
+### Changed
+
+- Added scriptanalyzer exceptions for "PSUseSingularNouns" per [issue #40](https://github.com/techservicesillinois/SecOps-Powershell-Qualys/issues/40)
+
+## [1.3.3] - 2021-08-26
+
+### Added
+
+- New private function Format-IPAddressGroup created to centralize logic for formatting IP addresses for API calls.
+-
+
+### Changed
+
+- Added scriptanalyzer exceptions for "PSUseSingularNouns" per [issue #40](https://github.com/techservicesillinois/SecOps-Powershell-Qualys/issues/40)
 
 ## [1.3.2] - 2021-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New private function Format-IPAddressGroup created to centralize logic for formatting IP addresses for API calls.
--
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added blank scriptanalyzer param for 'CheckID' on all scripts using the 'PSUseSingularNouns' attribute as this was causing errors
 - Update all Markdown Help
 
-## [1.3.3] - 2021-08-26
+## [1.3.4] - 2021-08-26
 
 ### Added
 

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofIQualys.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.2'
+ModuleVersion = '1.4.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -89,7 +89,8 @@ FunctionsToExport = @(
     'Disable-QualysUser',
     'Enable-QualysUser',
     'Get-QualysScanSummary',
-    'Get-QualysAPICallCount'
+    'Get-QualysAPICallCount',
+    'Stop-QualysScan'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
@@ -20,7 +20,7 @@
     #>
     function Add-QualysAssetGroups{
         [CmdletBinding()]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
         param (
             [Parameter(Mandatory=$true)]

--- a/src/UofIQualys/functions/public/Add-QualysHostAssets.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysHostAssets.ps1
@@ -10,7 +10,7 @@
 #>
 function Add-QualysHostAssets{
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
         [Parameter(Mandatory=$true)]

--- a/src/UofIQualys/functions/public/Get-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysAssetGroups.ps1
@@ -19,7 +19,7 @@
     #>
 function Get-QualysAssetGroups{
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
         [String]$Identity,

--- a/src/UofIQualys/functions/public/Get-QualysHostAssets.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysHostAssets.ps1
@@ -8,7 +8,7 @@
     #>
 function Get-QualysHostAssets{
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
 

--- a/src/UofIQualys/functions/public/Get-QualysScanSchedules.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysScanSchedules.ps1
@@ -14,7 +14,7 @@
 #>
 function Get-QualysScanSchedules{
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
         [String]$ID,

--- a/src/UofIQualys/functions/public/Get-QualysScans.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysScans.ps1
@@ -31,7 +31,7 @@
 #>
 function Get-QualysScans{
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
         [Alias('scan_ref')]

--- a/src/UofIQualys/functions/public/Remove-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Remove-QualysAssetGroups.ps1
@@ -10,7 +10,7 @@
     #>
     function Remove-QualysAssetGroups{
         [CmdletBinding(SupportsShouldProcess)]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
         param (
             [Parameter(Mandatory=$true)]

--- a/src/UofIQualys/functions/public/Set-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Set-QualysAssetGroups.ps1
@@ -26,7 +26,7 @@
     #>
     function Set-QualysAssetGroups{
         [CmdletBinding(SupportsShouldProcess)]
-        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+        [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
         param (
             [Parameter(Mandatory=$true)]

--- a/src/UofIQualys/functions/public/Start-QualysScan.ps1
+++ b/src/UofIQualys/functions/public/Start-QualysScan.ps1
@@ -44,7 +44,12 @@ function Start-QualysScan{
     )
 
     process{
-        $Target = $AssetGroups ? $AssetGroups : $IPs
+        If($AssetGroups){
+            $Target = $AssetGroups
+        }
+        Else{
+            $Target = $IPs
+        }
         if ($PSCmdlet.ShouldProcess("$($Target)")){
             $RestSplat = @{
                 Method = 'POST'

--- a/src/UofIQualys/functions/public/Start-QualysScan.ps1
+++ b/src/UofIQualys/functions/public/Start-QualysScan.ps1
@@ -44,12 +44,7 @@ function Start-QualysScan{
     )
 
     process{
-        If($AssetGroups){
-            $Target = $AssetGroups
-        }
-        Else{
-            $Target = $IPs
-        }
+        $Target = $AssetGroups ? $AssetGroups : $IPs
         if ($PSCmdlet.ShouldProcess("$($Target)")){
             $RestSplat = @{
                 Method = 'POST'

--- a/src/UofIQualys/functions/public/Stop-QualysScan.ps1
+++ b/src/UofIQualys/functions/public/Stop-QualysScan.ps1
@@ -16,7 +16,7 @@ function Stop-QualysScan{
     )
 
     process{
-        if ($PSCmdlet.ShouldProcess("$($ScanRef)")){
+        if ($PSCmdlet.ShouldProcess("$($ScanRef)","Stop")){
             $RestSplat = @{
                 Method = 'POST'
                 RelativeURI = 'scan/'

--- a/src/UofIQualys/functions/public/Stop-QualysScan.ps1
+++ b/src/UofIQualys/functions/public/Stop-QualysScan.ps1
@@ -1,0 +1,37 @@
+﻿<#
+.Synopsis
+    Launch vulnerability scan in the user’s account. Only targeting asset groups is supported currently. Support for targeting by IPs to be added later.
+.DESCRIPTION
+    Launch vulnerability scan in the user’s account. Only targeting asset groups is supported currently. Support for targeting by IPs to be added later.
+.PARAMETER ScanRef
+    The target FQDN for a vulnerability scan. Multiple values are comma separated.
+    You can specify FQDNs in combination with IPs and asset groups
+.EXAMPLE
+    Start-QualysScan -Title 'Test Scan' -AssetGroups 'Test Asset Group'
+#>
+function Stop-QualysScan{
+    [CmdletBinding(SupportsShouldProcess)]
+    param (
+        [Alias('scan_ref')]
+        [String]$ScanRef
+    )
+
+    process{
+        if ($PSCmdlet.ShouldProcess("$($ScanRef)")){
+            $RestSplat = @{
+                Method = 'POST'
+                RelativeURI = 'scan/'
+                Body = @{
+                    action = 'cancel'
+                    echo_request = '1'
+                    scan_ref = $ScanRef
+                }
+            }
+
+            $Response = Invoke-QualysRestCall @RestSplat
+            If($Response){
+                Write-Verbose -Message $Response
+            }
+        }
+    }
+}

--- a/src/UofIQualys/functions/public/Stop-QualysScan.ps1
+++ b/src/UofIQualys/functions/public/Stop-QualysScan.ps1
@@ -1,13 +1,12 @@
 ﻿<#
 .Synopsis
-    Launch vulnerability scan in the user’s account. Only targeting asset groups is supported currently. Support for targeting by IPs to be added later.
+    Stop a vulnerability scan in the user’s account.
 .DESCRIPTION
-    Launch vulnerability scan in the user’s account. Only targeting asset groups is supported currently. Support for targeting by IPs to be added later.
+    Stop a vulnerability scan in the user’s account.
 .PARAMETER ScanRef
-    The target FQDN for a vulnerability scan. Multiple values are comma separated.
-    You can specify FQDNs in combination with IPs and asset groups
+    The target ScanRef for a vulnerability scan.
 .EXAMPLE
-    Start-QualysScan -Title 'Test Scan' -AssetGroups 'Test Asset Group'
+    Stop-QualysScan -ScanRef 'scan/1633304415.63272'
 #>
 function Stop-QualysScan{
     [CmdletBinding(SupportsShouldProcess)]

--- a/src/UofIQualys/functions/public/Test-QualysHostAssets.ps1
+++ b/src/UofIQualys/functions/public/Test-QualysHostAssets.ps1
@@ -11,7 +11,7 @@
 function Test-QualysHostAssets{
     [OutputType([bool])]
     [CmdletBinding()]
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns',
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
         [Parameter(Mandatory)]

--- a/src/help/Add-QualysAssetGroups.md
+++ b/src/help/Add-QualysAssetGroups.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Add-QualysHostAssets.md
+++ b/src/help/Add-QualysHostAssets.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Add-QualysScanSchedule.md
+++ b/src/help/Add-QualysScanSchedule.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Add-QualysUser.md
+++ b/src/help/Add-QualysUser.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Disable-QualysUser.md
+++ b/src/help/Disable-QualysUser.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Enable-QualysUser.md
+++ b/src/help/Enable-QualysUser.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Get-QualysAPICallCount.md
+++ b/src/help/Get-QualysAPICallCount.md
@@ -5,25 +5,25 @@ online version:
 schema: 2.0.0
 ---
 
-# Get-QualysHostAssets
+# Get-QualysAPICallCount
 
 ## SYNOPSIS
-Returns an array of all host assets (IPs) in Qualys
+Returns the number of times Invoke-QualysRestCall is called
 
 ## SYNTAX
 
 ```
-Get-QualysHostAssets [<CommonParameters>]
+Get-QualysAPICallCount [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Returns an array of all host assets (IPs) in Qualys
+Returns the number of times Invoke-QualysRestCall is called
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Get-QualysHostAssets
+Get-QualysAPICallCount
 ```
 
 ## PARAMETERS
@@ -35,6 +35,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## OUTPUTS
 
+### System.Int32
 ## NOTES
 
 ## RELATED LINKS

--- a/src/help/Get-QualysAssetGroups.md
+++ b/src/help/Get-QualysAssetGroups.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Get-QualysScanSchedules.md
+++ b/src/help/Get-QualysScanSchedules.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Get-QualysScanSummary.md
+++ b/src/help/Get-QualysScanSummary.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Get-QualysScans.md
+++ b/src/help/Get-QualysScans.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---
@@ -9,7 +9,7 @@ schema: 2.0.0
 
 ## SYNOPSIS
 List vulnerability scans in the user's account.
-By default the output lists scans launched in the past 30 days
+By default the output lists unprocessed scans launched in the past 30 days
 
 ## SYNTAX
 
@@ -20,7 +20,7 @@ Get-QualysScans [[-ScanRef] <String>] [[-State] <String>] [-Processed] [[-Type] 
 
 ## DESCRIPTION
 List vulnerability scans in the user's account.
-By default the output lists scans launched in the past 30 days
+By default the output lists unprocessed scans launched in the past 30 days
 
 ## EXAMPLES
 
@@ -66,7 +66,8 @@ Accept wildcard characters: False
 ```
 
 ### -Processed
-Specify to show only scans that have been processed
+Specify to show only scans that have been processed.
+Processed scans are not included by default
 
 ```yaml
 Type: SwitchParameter

--- a/src/help/Get-QualysUser.md
+++ b/src/help/Get-QualysUser.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Invoke-QualysRestCall.md
+++ b/src/help/Invoke-QualysRestCall.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/New-QualysSession.md
+++ b/src/help/New-QualysSession.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Remove-QualysAssetGroups.md
+++ b/src/help/Remove-QualysAssetGroups.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Set-QualysAssetGroups.md
+++ b/src/help/Set-QualysAssetGroups.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Set-QualysScanSchedule.md
+++ b/src/help/Set-QualysScanSchedule.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Set-QualysUser.md
+++ b/src/help/Set-QualysUser.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Start-QualysScan.md
+++ b/src/help/Start-QualysScan.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---

--- a/src/help/Stop-QualysScan.md
+++ b/src/help/Stop-QualysScan.md
@@ -5,39 +5,38 @@ online version:
 schema: 2.0.0
 ---
 
-# Remove-QualysScanSchedule
+# Stop-QualysScan
 
 ## SYNOPSIS
-Removes a scan schedule from Qualys
+Stop a vulnerability scan in the user's account.
 
 ## SYNTAX
 
 ```
-Remove-QualysScanSchedule [-Identity] <String> [-WhatIf] [-Confirm] [<CommonParameters>]
+Stop-QualysScan [[-ScanRef] <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-Removes a scan schedule from Qualys
+Stop a vulnerability scan in the user's account.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-Remove-QualysScanSchedule -Identity "3848863"
+Stop-QualysScan -ScanRef 'scan/1633304415.63272'
 ```
 
 ## PARAMETERS
 
-### -Identity
-The ID of the Scan Schedule to delete.
-Only one Identity may be provided per API call.
+### -ScanRef
+The target ScanRef for a vulnerability scan.
 
 ```yaml
 Type: String
 Parameter Sets: (All)
-Aliases:
+Aliases: scan_ref
 
-Required: True
+Required: False
 Position: 1
 Default value: None
 Accept pipeline input: False

--- a/src/help/Test-QualysHostAssets.md
+++ b/src/help/Test-QualysHostAssets.md
@@ -1,6 +1,6 @@
 ---
-external help file: Qualys-help.xml
-Module Name: Qualys
+external help file: UofIQualys-help.xml
+Module Name: UofIQualys
 online version:
 schema: 2.0.0
 ---


### PR DESCRIPTION
## [1.4.0] - 2021-10-05

### Added

- New function Stop-QualysScan

### Changed

- Added blank scriptanalyzer param for 'CheckID' on all scripts using the 'PSUseSingularNouns' attribute as this was causing errors
- Update all Markdown Help