### PR TITLE
min powershell version set to 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.4.4] - 2021-12-22
+
+### Changed
+
+- Minimum Powershell version set to 7
+
 ## [1.4.3] - 2021-11-23
 
 ### Changed

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -31,7 +31,7 @@ Copyright = 'The University of Illinois Board of Trustees'
 Description = 'This Powershell module acts as a wrapper for the Qualys REST API, allowing you to create scripts that run system administration commands against your Qualys account'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '5.1'
+PowerShellVersion = '7.0.0'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''


### PR DESCRIPTION
## [1.4.4] - 2021-12-22

### Changed

- Minimum Powershell version set to 7