### PR TITLE
Powershell 5.1 compatability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Comments removed from json file for Powershell 5.1 compatability
 - Ternary operator from Start-QualysScan for Powershell 5.1 compatability
+- UofI specific language in a comment
 
 ## [1.4.4] - 2021-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.4.5] - 2022-01-07
+
+### Changed
+
+- Minimum Powershell version set to 5.1
+
+### Removed
+
+- Comments removed from json file for Powershell 5.1 compatability
+- Ternary operator from Start-QualysScan for Powershell 5.1 compatability
+
 ## [1.4.4] - 2021-12-22
 
 ### Changed

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -31,7 +31,7 @@ Copyright = 'The University of Illinois Board of Trustees'
 Description = 'This Powershell module acts as a wrapper for the Qualys REST API, allowing you to create scripts that run system administration commands against your Qualys account'
 
 # Minimum version of the PowerShell engine required by this module
-PowerShellVersion = '7.0.0'
+PowerShellVersion = '5.1'
 
 # Name of the PowerShell host required by this module
 # PowerShellHostName = ''

--- a/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
@@ -10,7 +10,7 @@
 .PARAMETER Comments
     Description or comments about the group; max 255 characters
 .PARAMETER Division
-    The Division of the Asset Group, typically the Owner Code from CDB
+    The Division of the Asset Group
 .PARAMETER DefaultScanner
     The ID of the scanner to use as the default scanner for this asset group
 .EXAMPLE

--- a/src/UofIQualys/functions/public/Start-QualysScan.ps1
+++ b/src/UofIQualys/functions/public/Start-QualysScan.ps1
@@ -44,8 +44,13 @@ function Start-QualysScan{
     )
 
     process{
-        $Target = $AssetGroups ? $AssetGroups : $IPs
-        if ($PSCmdlet.ShouldProcess("$($Target)")){
+        If($AssetGroups){
+            $Target = $AssetGroups
+        }
+        Else{
+            $Target = $IPs
+        }
+        If($PSCmdlet.ShouldProcess("$($Target)")){
             $RestSplat = @{
                 Method = 'POST'
                 RelativeURI = 'scan/'

--- a/src/UofIQualys/settings.json
+++ b/src/UofIQualys/settings.json
@@ -1,9 +1,4 @@
 {
-  //BaseURI of Qualys
-  //Production
   "BaseURI": ["https://qualysguard.qualys.com/api/2.0/fo/"],
   "BasicAuthURI": ["https://qualysguard.qualys.com/"]
-  //Dev
-  // "BaseURI": ["https://qualysapi.qg3.apps.qualys.com/api/2.0/fo/"],
-  // "BasicAuthURI": ["https://qualysapi.qg3.apps.qualys.com/"]
 }


### PR DESCRIPTION
## [1.4.5] - 2022-01-07

### Changed

- Minimum Powershell version set to 5.1

### Removed

- Comments removed from json file for Powershell 5.1 compatability
- Ternary operator from Start-QualysScan for Powershell 5.1 compatability