### PR TITLE
Invoke restcall retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.5.0] - 2022-09-09
+
+### Changed
+
+- Added retry to Invoke-QualysRestCall to compensate for short periods where the Qualys api is unreachable
+
 ## [1.4.5] - 2022-01-07
 
 ### Changed

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofIQualys.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.4.5'
+ModuleVersion = '1.5.0'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofIQualys/functions/public/Invoke-QualysRestCall.ps1
+++ b/src/UofIQualys/functions/public/Invoke-QualysRestCall.ps1
@@ -62,9 +62,16 @@ function Invoke-QualysRestCall {
             $IVRSplat['Uri'] = "$($Script:Settings.BaseURI)$RelativeURI"
             $IVRSplat.add('WebSession',$Script:Session)
         }
-
-        Invoke-RestMethod @IVRSplat
-        $Script:APICallCount++
+        #Retry parameters only available in Powershell 7.1+, so we use a try/catch to retry calls once to compensate for short periods where the Qualys api is unreachable
+        try{
+            Invoke-RestMethod @IVRSplat
+            $Script:APICallCount++
+        }
+        catch{
+            Start-Sleep -Seconds 4
+            Invoke-RestMethod @IVRSplat
+            $Script:APICallCount++
+        }
     }
 
     end {


### PR DESCRIPTION
## [1.5.0] - 2022-09-09

### Changed

- Added retry to Invoke-QualysRestCall to compensate for short periods where the Qualys API is unreachable