### PR TITLE
Fix/issue 58

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QualysAsset class: This class defines objects with properties that include all details returned by the QPS API about a host asset, plus optional metadata for function and method use.
 - QualysTag class: This class defines objects with properties that include all details returned by the QPS API about a tag, plus optional metadata and parent tag.
 - Support using environment variables to automatically override settings.json script-scoped parameters.
+- Invoke-QualysTagRestCall: Modify the tagging functions to use this modified version of Invoke-QualysRestCall. The BaseURI for tagging endpoints is different from User Basic auth endpoints and there is nothing to clearly distinguish the two.
+- Added the tagging Base URI to the settings.json
 
 ### Added
 

--- a/src/UofIQualys/UofIQualys.psm1
+++ b/src/UofIQualys/UofIQualys.psm1
@@ -1,6 +1,5 @@
 $Script:Settings = Get-Content -Path "$PSScriptRoot\settings.json" | ConvertFrom-Json
 
-# Check $env:BasicAuthURI and $env:BaseURI and set $script:Settings.BasicAuthURI and $script:Settings.BaseURI from environment variables if present
 # This will override the settings.json file if required.
 if ($env:QualysSettings) {
     $script:Settings= $env:QualysSettings | ConvertFrom-Json

--- a/src/UofIQualys/functions/public/Add-QualysTagAssignment.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysTagAssignment.ps1
@@ -64,7 +64,7 @@ function Add-QualysTagAssignment {
     }
 
     try {
-        Invoke-QualysRestCall @RestSplat
+        Invoke-QualysTagRestCall @RestSplat
     }
     catch {
         # Dig into the exception to get the Response details.

--- a/src/UofIQualys/functions/public/Get-QualysAsset.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysAsset.ps1
@@ -65,7 +65,7 @@ $BodyAsset = "<ServiceRequest>
     $OrigProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
 
-    # Use Invoke-QualysRestCall to make the API request
+    # Use Invoke-QualysTagRestCall to make the API request
     $RestSplat = @{
         Method = 'POST'
         RelativeURI = 'qps/rest/2.0/search/am/hostasset'
@@ -73,7 +73,7 @@ $BodyAsset = "<ServiceRequest>
         Credential = $Credential
     }
 
-    $ResponseContent = [Xml](Invoke-QualysRestCall @RestSplat)
+    $ResponseContent = [Xml](Invoke-QualysTagRestCall @RestSplat)
 
     if ($null -eq $ResponseContent.ServiceResponse.data.HostAsset) {
         return $null

--- a/src/UofIQualys/functions/public/Get-QualysAssetInventory.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysAssetInventory.ps1
@@ -47,7 +47,7 @@ function Get-QualysAssetInventory {
             Credential  = $Credential
         }
 
-        $ResponseHostAdd = [xml](Invoke-QualysRestCall @RestSplat)
+        $ResponseHostAdd = [xml](Invoke-QualysTagRestCall @RestSplat)
 
         $ProgressPreference = $OrigProgressPreference
 

--- a/src/UofIQualys/functions/public/Get-QualysTag.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysTag.ps1
@@ -69,7 +69,7 @@ function Get-QualysTag {
     $OrigProgressPreference = $ProgressPreference
     $ProgressPreference = 'SilentlyContinue'
 
-    # Use Invoke-QualysRestCall to make the API request
+    # Use Invoke-QualysTagRestCall to make the API request
     $RestSplat = @{
         Method      = 'POST'
         RelativeURI = 'qps/rest/2.0/search/am/tag'
@@ -77,7 +77,7 @@ function Get-QualysTag {
         XmlBody     = $BodyTag
     }
 
-    $ResponseContent = [xml](Invoke-QualysRestCall @RestSplat)
+    $ResponseContent = [xml](Invoke-QualysTagRestCall @RestSplat)
 
     if ($null -eq $ResponseContent.ServiceResponse.data.Tag) {
         return $null

--- a/src/UofIQualys/functions/public/Invoke-QualysRestCall.ps1
+++ b/src/UofIQualys/functions/public/Invoke-QualysRestCall.ps1
@@ -28,8 +28,6 @@ function Invoke-QualysRestCall {
         [String]$Method,
         [Parameter(Mandatory=$true, ParameterSetName='Body')]
         [hashtable]$Body,
-        [Parameter(Mandatory=$true, ParameterSetName='XmlBody')]
-        [String]$XmlBody,
         [System.Management.Automation.PSCredential]$Credential
     )
 

--- a/src/UofIQualys/functions/public/Invoke-QualysTagRestCall.ps1
+++ b/src/UofIQualys/functions/public/Invoke-QualysTagRestCall.ps1
@@ -26,8 +26,6 @@ function Invoke-QualysTagRestCall {
         [String]$RelativeURI,
         [Parameter(Mandatory=$true)]
         [String]$Method,
-        [Parameter(Mandatory=$true, ParameterSetName='Body')]
-        [hashtable]$Body,
         [Parameter(Mandatory=$true, ParameterSetName='XmlBody')]
         [String]$XmlBody,
         [System.Management.Automation.PSCredential]$Credential

--- a/src/UofIQualys/functions/public/Invoke-QualysTagRestCall.ps1
+++ b/src/UofIQualys/functions/public/Invoke-QualysTagRestCall.ps1
@@ -7,8 +7,8 @@
     The relativeURI you wish to make a call to. Ex: asset/ip/
 .PARAMETER Method
     Method of the REST call Ex: GET
-.PARAMETER Body
-    Body of the REST call as a hashtable
+.PARAMETER XmlBody
+    Body of the REST call as an XML string
 .PARAMETER Credential
     Optionally used for making REST calls that require Basic Authentication
 .EXAMPLE
@@ -19,7 +19,7 @@
     Invoke-QualysRestCall -RelativeURI asset/ip/ -Method GET -Body $Body
     This will return an array of all host assets (IPs) in Qualys
 #>
-function Invoke-QualysRestCall {
+function Invoke-QualysTagRestCall {
     [CmdletBinding(DefaultParameterSetName='Body')]
     param (
         [Parameter(Mandatory=$true)]
@@ -52,11 +52,16 @@ function Invoke-QualysRestCall {
             }
             Method = $Method
             URI = [string]::Empty
-            Body = $Body
+        }
+
+        if($PSCmdlet.ParameterSetName -eq 'XmlBody'){
+            $IVRSplat['Body'] = $XmlBody
+            $IVRSplat['Headers'].Add('Content-Type','application/xml')
+            $IVRSplat['Headers'].Add('Accept','application/xml')
         }
 
         if($Credential){
-            $IVRSplat['Uri'] = "$($Script:Settings.BasicAuthURI)$RelativeURI"
+            $IVRSplat['Uri'] = "$($Script:Settings.TaggingAuthURI)$RelativeURI"
             $BasicAuth = ('Basic {0}' -f ([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $Credential.UserName,$Credential.GetNetworkCredential().Password)))))
             $IVRSplat['Headers'].add('Authorization',$BasicAuth)
         }

--- a/src/UofIQualys/functions/public/Remove-QualysTagAssignment.ps1
+++ b/src/UofIQualys/functions/public/Remove-QualysTagAssignment.ps1
@@ -61,7 +61,7 @@ function Remove-QualysTagAssignment {
         }
 
         try {
-            Invoke-QualysRestCall @RestSplat
+            Invoke-QualysTagRestCall @RestSplat
         }
         catch {
             # Dig into the exception to get the Response details.

--- a/src/UofIQualys/settings.json
+++ b/src/UofIQualys/settings.json
@@ -1,4 +1,5 @@
 {
   "BaseURI": ["https://qualysguard.qualys.com/api/2.0/fo/"],
-  "BasicAuthURI": ["https://qualysguard.qualys.com/"]
+  "BasicAuthURI": ["https://qualysguard.qualys.com/"],
+  "TaggingAuthURI": ["https://qualysapi.qualys.com/"]
 }


### PR DESCRIPTION
## Unreleased 6/24/2024

- Invoke-QualysTagRestCall: Modify the tagging functions to use this modified version of Invoke-QualysRestCall. The BaseURI for tagging endpoints is different from User Basic auth endpoints and there is nothing to clearly distinguish the two.
- Added the tagging Base URI to the settings.json