### PR TITLE
Get-QualysAMUser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+### Changed
+
+### Removed
+
 ## [1.8.0] - 2024-07-08
 
 ### Added
@@ -26,12 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Support using environment variables to automatically override settings.json script-scoped parameters.
-
-### Added
-
-### Changed
-
-### Removed
 
 ## [1.6.0] - 2023-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.8.0] - 2024-07-08
+
+### Added
+
 - Add-QualysAssetTagAssignment: This function takes an asset ID and a tag ID and adds the tag to the asset.
 - Get-QualysAsset: This function takes an asset name or ID and returns the asset object.
 - Get-QualysAssetInventory: Fetches all Qualys host asset objects.
@@ -14,11 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove-QualysTagAssignment: This function takes an asset ID and a tag ID and removes the tag from the asset.
 - QualysAsset class: This class defines objects with properties that include all details returned by the QPS API about a host asset, plus optional metadata for function and method use.
 - QualysTag class: This class defines objects with properties that include all details returned by the QPS API about a tag, plus optional metadata and parent tag.
-- Support using environment variables to automatically override settings.json script-scoped parameters.
-- Invoke-QualysTagRestCall: Modify the tagging functions to use this modified version of Invoke-QualysRestCall. The BaseURI for tagging endpoints is different from User Basic auth endpoints and there is nothing to clearly distinguish the two.
+- Invoke-QualysTagRestCall: The new tagging functions use this modified version of Invoke-QualysRestCall. The BaseURI for tagging endpoints is different from User Basic auth endpoints and there is nothing to clearly distinguish the two.
 - Added the tagging Base URI to the settings.json
 - Added Add-QualysUserTagAssignment: this function adds tag assignments to users.
 - Added functions Get-QualysReports and Save-QualysReport
+
+### Changed
+
+- Support using environment variables to automatically override settings.json script-scoped parameters.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Get-QualysAMUser: function that gets user information from the administration module. This supporting function is necessary for Add-QualysUserTagAssignment after discovering VMDR User IDs and Administration User IDs are not the same.
+- Invoke-QualysTagRestCall was missing from the module's functions to export.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Get-QualysAMUser: function that gets user information from the administration module. This supporting function is necessary for Add-QualysUserTagAssignment after discovering VMDR User IDs and Administration User IDs are not the same.
+
 ### Changed
+
+- Add-QualysUserTagAssignment: Now takes a User Login instead of ID and gets the AM ID by using the Get-QualysAMUser function.
 
 ### Removed
 

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofIQualys.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.0'
+ModuleVersion = '1.8.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -74,6 +74,7 @@ FunctionsToExport = @(
     'Test-QualysHostAssets',
     'Get-QualysHostAssets',
     'Invoke-QualysRestCall',
+    'Invoke-QualysTagRestCall',
     'Get-QualysAssetGroups',
     'Add-QualysAssetGroups',
     'Set-QualysAssetGroups',
@@ -101,7 +102,8 @@ FunctionsToExport = @(
     'Sync-QualysTagAssignment',
     'Add-QualysUserTagAssignment',
     'Get-QualysReports',
-    'Save-QualysReport'
+    'Save-QualysReport',
+    'Get-QualysAMUser'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/UofIQualys/functions/public/Add-QualysUserTagAssignment.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysUserTagAssignment.ps1
@@ -3,8 +3,8 @@
         Adds a tag to an user in Qualys.
     .DESCRIPTION
         This function takes a User ID and a Tag name and adds the tag to the user.
-    .PARAMETER UserID
-        The ID of the user to add the tag to.
+    .PARAMETER Login
+        The User Login of the user to add the tag to.
     .PARAMETER Tags
         An array of Names or IDs of tags to add to the user.
     .PARAMETER Credential
@@ -12,7 +12,6 @@
     .EXAMPLE
         Add-QualysTagAssignment -UserID "566158438" -Tag "0001-ctav-net_CDB-7725" -Credential $credential
     .NOTES
-        The easiest way to get the UserID is to use the Get-QualysUser function.
         The easiest way to get the tag ID is to use the Get-QualysTag function.
 #>
 function Add-QualysUserTagAssignment {
@@ -20,13 +19,15 @@ function Add-QualysUserTagAssignment {
     [CmdletBinding()]
     param (
         [parameter(Mandatory = $true)]
-        [Int64]$UserId,
+        [String]$Login,
         [parameter(Mandatory = $true)]
         [String[]]$Tags,
         [parameter(Mandatory = $true)]
         [System.Management.Automation.PSCredential]$Credential
 
     )
+
+    $UserID = (Get-QualysAMUser -Login $Login -Credential $Credential).id
 
     If($Tags[0] -match '\D'){
         $NameOrID = "name"

--- a/src/UofIQualys/functions/public/Get-QualysAMUser.ps1
+++ b/src/UofIQualys/functions/public/Get-QualysAMUser.ps1
@@ -1,0 +1,50 @@
+<#
+    .SYNOPSIS
+        Returns the Administration User object of a Qualys User.
+    .DESCRIPTION
+        Returns the Administration User object of a Qualys User.
+    .PARAMETER Login
+        The User Login of the user to get the AM object for.
+    .PARAMETER Credential
+        The credential object to log into Qualys.
+    .EXAMPLE
+        Get-QualysAMUser -Login "theun_zc" -Credential $credential
+#>
+function Get-QualysAMUser {
+
+    [CmdletBinding()]
+    param (
+        [parameter(Mandatory = $true)]
+        [String]$Login,
+        [parameter(Mandatory = $true)]
+        [System.Management.Automation.PSCredential]$Credential
+
+    )
+
+    $Body = @"
+<?xml version="1.0" encoding="UTF-8" ?>
+<ServiceRequest>
+	<filters>
+		<Criteria field="username" operator="EQUALS">$($Login)</Criteria>
+	</filters>
+	<preferences>
+		<limitResults>500</limitResults>
+	</preferences>
+</ServiceRequest>
+"@
+
+    $RestSplat = @{
+        RelativeUri = "qps/rest/2.0/search/am/user"
+        Method      = 'POST'
+        XmlBody     = $Body
+        Credential  = $Credential
+    }
+
+    try {
+        $Response = Invoke-QualysTagRestCall @RestSplat
+        $Response.ServiceResponse.data.user
+    }
+    catch {
+        Write-Error "Operation not successful: $($Response.ServiceResponse.responseErrorDetails)"
+    }
+}


### PR DESCRIPTION
## Unreleased

### Added

- Get-QualysAMUser: function that gets user information from the administration module. This supporting function is necessary for Add-QualysUserTagAssignment after discovering VMDR User IDs and Administration User IDs are not the same.

### Changed

- Add-QualysUserTagAssignment: Now takes a User Login instead of ID and gets the AM ID by using the Get-QualysAMUser function.