### PR TITLE
Set/Add Asset Group Enhancement and Purge Functionality 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.8.2] - 2024-11-21
+
+### Added
+
+- Remove-QualysHosts: Purges hosts based on IP from Qualys.
+
+### Changed
+
+- Set-QualysAssetGroups: Add Scanners parameter so you can add non-default scanners to asset groups
+- Add-QualysAssetGroups: Add Scanners parameter so you can add non-default scanners to asset groups
+
 ## [1.8.1] - 2024-07-15
 
 ### Added

--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -103,7 +103,8 @@ FunctionsToExport = @(
     'Add-QualysUserTagAssignment',
     'Get-QualysReports',
     'Save-QualysReport',
-    'Get-QualysAMUser'
+    'Get-QualysAMUser',
+    'Remove-QualysHosts'
     )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
@@ -13,6 +13,8 @@
     The Division of the Asset Group
 .PARAMETER DefaultScanner
     The ID of the scanner to use as the default scanner for this asset group
+.PARAMETER Scanners
+    Comma separated IDs of the scanners to assign to the asset group. Ex "1578772,1578773"
 .EXAMPLE
     Add-QualysAssetGroups -Title "My Asset Group"
 .EXAMPLE
@@ -28,7 +30,8 @@
             [String[]]$IPs,
             [String]$Comments,
             [String]$Division,
-            [Int]$DefaultScanner
+            [Int]$DefaultScanner,
+            [String]$Scanners
         )
 
         process{
@@ -58,6 +61,10 @@
             If($DefaultScanner){
                 $RestSplat.Body['appliance_ids'] = $DefaultScanner
                 $RestSplat.Body['default_appliance_id'] = $DefaultScanner
+            }
+
+            If($Scanners){
+                $RestSplat.Body['appliance_ids'] = $Scanners
             }
 
             $Response = Invoke-QualysRestCall @RestSplat

--- a/src/UofIQualys/functions/public/Remove-QualysHosts.ps1
+++ b/src/UofIQualys/functions/public/Remove-QualysHosts.ps1
@@ -11,6 +11,8 @@
 
 function Remove-QualysHosts{
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+            Justification = 'This is consistent with the vendors verbiage')]
     param (
         [Parameter(Mandatory=$true)]
         [String[]]$IPs

--- a/src/UofIQualys/functions/public/Remove-QualysHosts.ps1
+++ b/src/UofIQualys/functions/public/Remove-QualysHosts.ps1
@@ -1,0 +1,31 @@
+<#
+.Synopsis
+    Purges host assets from Qualys by IP
+.DESCRIPTION
+    Purges host assets from Qualys by IP
+.PARAMETER IPs
+    An array of IPs to purge from Qualys
+.EXAMPLE
+    Remove-QualysHosts -IPs ("192.168.1.1", "192.168.0.0")
+#>
+
+function Remove-QualysHosts{
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [String[]]$IPs
+    )
+
+    process{
+        $RestSplat = @{
+            Method = 'POST'
+            RelativeURI = 'asset/host/'
+            Body = @{
+                action = 'purge'
+                ips = ($IPs.Trim() -join ", ")
+            }
+        }
+        $Response = Invoke-QualysRestCall @RestSplat
+        $Response.BATCH_RETURN.RESPONSE.BATCH_LIST.BATCH
+    }
+}

--- a/src/UofIQualys/functions/public/Remove-QualysHosts.ps1
+++ b/src/UofIQualys/functions/public/Remove-QualysHosts.ps1
@@ -10,7 +10,7 @@
 #>
 
 function Remove-QualysHosts{
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
             Justification = 'This is consistent with the vendors verbiage')]
     param (
@@ -19,15 +19,17 @@ function Remove-QualysHosts{
     )
 
     process{
-        $RestSplat = @{
-            Method = 'POST'
-            RelativeURI = 'asset/host/'
-            Body = @{
-                action = 'purge'
-                ips = ($IPs.Trim() -join ", ")
+        if ($PSCmdlet.ShouldProcess("$($IPs.count) IPs Will be purged from Qualys")){
+            $RestSplat = @{
+                Method = 'POST'
+                RelativeURI = 'asset/host/'
+                Body = @{
+                    action = 'purge'
+                    ips = ($IPs.Trim() -join ", ")
+                }
             }
+            $Response = Invoke-QualysRestCall @RestSplat
+            $Response.BATCH_RETURN.RESPONSE.BATCH_LIST.BATCH
         }
-        $Response = Invoke-QualysRestCall @RestSplat
-        $Response.BATCH_RETURN.RESPONSE.BATCH_LIST.BATCH
     }
 }

--- a/src/UofIQualys/functions/public/Set-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Set-QualysAssetGroups.ps1
@@ -19,6 +19,8 @@
     The Division of the Asset Group, typically the Owner Code from CDB
 .PARAMETER DefaultScanner
     The ID of the scanner to use as the default scanner for this asset group
+.PARAMETER Scanners
+    Comma separated IDs of the scanners to assign to the asset group. Ex "1578772,1578773"
 .EXAMPLE
     Set-QualysAssetGroups -Identity '7445535' -Title "My Edited Asset Group Title"
 .EXAMPLE
@@ -37,7 +39,8 @@
             [String[]]$RemoveIPs,
             [String]$Comments,
             [String]$Division,
-            [Int]$DefaultScanner
+            [Int]$DefaultScanner,
+            [String]$Scanners
         )
 
         process{
@@ -88,6 +91,10 @@
                 If($DefaultScanner){
                     $RestSplat.Body['add_appliance_ids'] = $DefaultScanner
                     $RestSplat.Body['set_default_appliance_id'] = $DefaultScanner
+                }
+
+                If($Scanners){
+                    $RestSplat.Body['add_appliance_ids'] = $Scanners
                 }
 
                 $Response = Invoke-QualysRestCall @RestSplat


### PR DESCRIPTION
## [1.8.2] - 2024-11-21

### Added

- Remove-QualysHosts: Purges hosts based on IP from Qualys.

### Changed

- Set-QualysAssetGroups: Add Scanners parameter so you can add non-default scanners to asset groups
- Add-QualysAssetGroups: Add Scanners parameter so you can add non-default scanners to asset groups