### PR TITLE
Bugfix add qualys asset groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.8.3] - 2025-01-06
+
+### Changed
+
+- Add-QualysAssetGroups: DefaultScanner parameter was being overwritten by Scanner parameter. This has been fixed.
+
 ## [1.8.2] - 2024-11-21
 
 ### Added

--- a/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
@@ -30,7 +30,7 @@
             [String[]]$IPs,
             [String]$Comments,
             [String]$Division,
-            [Int]$DefaultScanner,
+            [String]$DefaultScanner,
             [String]$Scanners
         )
 
@@ -64,7 +64,12 @@
             }
 
             If($Scanners){
-                $RestSplat.Body['appliance_ids'] = $Scanners
+                If($DefaultScanner){
+                    $RestSplat.Body['appliance_ids'] += ",$($Scanners)"
+                }
+                Else{
+                    $RestSplat.Body['appliance_ids'] = $Scanners
+                }
             }
 
             $Response = Invoke-QualysRestCall @RestSplat


### PR DESCRIPTION
## [1.8.3] - 2025-01-06

### Changed

- Add-QualysAssetGroups: DefaultScanner parameter was being overwritten by Scanner parameter. This has been fixed.