### PR TITLE
Write Errors when Basic Auth API Calls Fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.8.4] - 2025-01-08
+
+### Changed
+
+- Add-QualysUser: DefaultScanner parameter was being overwritten by Scanner parameter. This has been fixed.
+
 ## [1.8.3] - 2025-01-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add-QualysUser and Set-QualysUser: Made output more useful for troubleshooting
+- Add-QualysUser and Set-QualysUser: Made output more useful for troubleshooting, and error when there is a "failed" status because the API is returning a 200 even when the call fails.
 
 ## [1.8.3] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-## [1.8.4] - 2025-01-08
+## [1.8.4] - 2025-01-16
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add-QualysUser: DefaultScanner parameter was being overwritten by Scanner parameter. This has been fixed.
+- Add-QualysUser and Set-QualysUser: Made output more useful for troubleshooting
 
 ## [1.8.3] - 2025-01-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+## [1.8.3] - 2025-01-06
+
+### Changed
+
+- Add-QualysAssetGroups: DefaultScanner parameter was being overwritten by Scanner parameter. This has been fixed.
+
 ## [1.8.2] - 2024-11-21
 
 ### Added

--- a/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysAssetGroups.ps1
@@ -30,7 +30,7 @@
             [String[]]$IPs,
             [String]$Comments,
             [String]$Division,
-            [Int]$DefaultScanner,
+            [String]$DefaultScanner,
             [String]$Scanners
         )
 
@@ -64,7 +64,12 @@
             }
 
             If($Scanners){
-                $RestSplat.Body['appliance_ids'] = $Scanners
+                If($DefaultScanner){
+                    $RestSplat.Body['appliance_ids'] += ",$($Scanners)"
+                }
+                Else{
+                    $RestSplat.Body['appliance_ids'] = $Scanners
+                }
             }
 
             $Response = Invoke-QualysRestCall @RestSplat

--- a/src/UofIQualys/functions/public/Add-QualysUser.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysUser.ps1
@@ -120,7 +120,7 @@ function Add-QualysUser{
             Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
         }
         else {
-            $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
+            Write-Error -Exception $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
         }
     }
 }

--- a/src/UofIQualys/functions/public/Add-QualysUser.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysUser.ps1
@@ -120,11 +120,7 @@ function Add-QualysUser{
             Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
         }
         else {
-<<<<<<< HEAD
             Write-Error -Exception $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
-=======
-            $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
->>>>>>> origin/main
         }
     }
 }

--- a/src/UofIQualys/functions/public/Add-QualysUser.ps1
+++ b/src/UofIQualys/functions/public/Add-QualysUser.ps1
@@ -116,11 +116,11 @@ function Add-QualysUser{
         }
 
         $Response = Invoke-QualysRestCall @RestSplat
-        if ($Response.USER_OUTPUT.RETURN.MESSAGE) {
-            Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE
+        if ($Response.USER_OUTPUT.RETURN.status -ne 'FAILED') {
+            Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
         }
         else {
-            $Response
+            $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
         }
     }
 }

--- a/src/UofIQualys/functions/public/Set-QualysUser.ps1
+++ b/src/UofIQualys/functions/public/Set-QualysUser.ps1
@@ -107,11 +107,7 @@ function Set-QualysUser{
                 Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
             }
             else {
-<<<<<<< HEAD
                 Write-Error -Exception $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
-=======
-                $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
->>>>>>> origin/main
             }
         }
     }

--- a/src/UofIQualys/functions/public/Set-QualysUser.ps1
+++ b/src/UofIQualys/functions/public/Set-QualysUser.ps1
@@ -103,11 +103,11 @@ function Set-QualysUser{
             }
 
             $Response = Invoke-QualysRestCall @RestSplat
-            if ($Response.USER_OUTPUT.RETURN.MESSAGE) {
-                Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE
+            if ($Response.USER_OUTPUT.RETURN.status -ne 'FAILED') {
+                Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
             }
             else {
-                $Response.USER_OUTPUT.RETURN.MESSAGE
+                $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
             }
         }
     }

--- a/src/UofIQualys/functions/public/Set-QualysUser.ps1
+++ b/src/UofIQualys/functions/public/Set-QualysUser.ps1
@@ -107,7 +107,7 @@ function Set-QualysUser{
                 Write-Verbose -Message $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
             }
             else {
-                $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
+                Write-Error -Exception $Response.USER_OUTPUT.RETURN.MESSAGE.'#cdata-section'
             }
         }
     }


### PR DESCRIPTION
## [1.8.4] - 2025-01-16

### Changed

- Add-QualysUser and Set-QualysUser: Made output more useful for troubleshooting, and error when there is a "failed" status because the API is returning a 200 even when the call fails.
