### PR TITLE
Release 1.8.4

### DIFF
--- a/src/UofIQualys/UofIQualys.psd1
+++ b/src/UofIQualys/UofIQualys.psd1
@@ -10,7 +10,7 @@
 RootModule = 'UofIQualys.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.8.2'
+ModuleVersion = '1.8.4'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()


### PR DESCRIPTION
## [1.8.4] - 2025-01-16

### Changed

- Add-QualysUser and Set-QualysUser: Made output more useful for troubleshooting, and error when there is a "failed" status because the API is returning a 200 even when the call fails.

## [1.8.3] - 2025-01-06

### Changed

- Add-QualysAssetGroups: DefaultScanner parameter was being overwritten by Scanner parameter. This has been fixed.

